### PR TITLE
Pre  [pylint, fix-encoding-pragma]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.tox/
 /coverage/
-/venv/
+/py_env-default/
 __pycache__/
 /.coverage
 *.egg*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@
     -   id: debug-statements
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
+    -   id: fix-encoding-pragma
+        exclude: setup.py
     -   id: forbid-new-submodules
     -   id: name-tests-test
     -   id: requirements-txt-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,13 @@
+-   repo: local
+    hooks:
+    -   id: pylint
+        name: Pylint
+        entry: pylint
+        language: python
+        files: \.py$
+        exclude: setup.py
+        additional_dependencies:
+        -   pylint
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     sha: 96fb7fa10f2f4c11ed33482a9ad7474251e5e97f
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,17 +18,6 @@ To update the project from within the project's folder you can run the following
 git pull --rebase
 ```
 
-### Virtual Environment
-
-It is better to keep a project specific virtual environment to not mix package versions between different projects.
-
-To create and activate a virtual environment use:
-
-```bash
-virtualenv venv
-. venv/bin/activate
-```
-
 ### Building
 
 Install the project's dependencies.
@@ -42,6 +31,19 @@ Install [pre-commit](http://pre-commit.com) hooks.
 
 ```bash
 pre-commit install
+```
+
+### Virtual Environment
+
+It is better to keep a project specific virtual environment to not mix package versions between different projects.
+
+A virtual environment is automatically created by `pre-commit` called `py_env-default`. If not created, run
+`pre-commit run --all-files`.
+
+To activate the virtual environment use:
+
+```bash
+. py_env-default/bin/activate
 ```
 
 ### Commit Guidelines


### PR DESCRIPTION
# What?
1. Adds pre-hook pylint (local)
2. Adds pre-hook fix-encoding-pragma
3. Changes CONTRIBUTING.md
4. Changes .gitignore

# Why?
1. Pylint: To check for formatting errors before committing
2. Pre-Commit generates it's own virtualenv by name py_env-default. Thus requires changing .gitignore and CONTRIBUTING.md virtual environment section
3. `fix-encoding-pragma` - sets the strings encoding to utf-8