### PR TITLE
Config fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,78 @@
-/.tox/
-/coverage/
-/py_env-default/
+### Python template
+# Byte-compiled / optimized / DLL files
 __pycache__/
-/.coverage
-*.egg*
-*.pyc
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+/coverage/
+
+# Translations
+*.mo
+*.pot
+
+# Sphinx documentation
+docs/build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+/py_env-default/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@
         entry: pylint
         language: python
         files: \.py$
-        exclude: setup.py
         args:
         - --output-format=parseable
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@
         language: python
         files: \.py$
         exclude: setup.py
+        args:
+        - --output-format=parseable
         additional_dependencies:
         -   pylint
 -   repo: git://github.com/pre-commit/pre-commit-hooks

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """
 Setup script.
 """

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{34,35}, pypy, lint, pre-commit
+    py{27,34,35}, pypy, lint, pre-commit
 skip_missing_interpreters =
     True
 


### PR DESCRIPTION
# What?
1. Adds in .gitignore python template
2. Moves pylint ignore form .pre-commit-config.yaml to setup.py
3. Pretty print pylint with filenames and line numbers
4. Adds py27 in tox

# Why?
1. Standard python .gitignore
2. More files might need to get ignored while putting them in regex is better than file themselves containing the rule to avoid pylint check
3. Pretty print for better readability 
4. Env py2.7 is mentioned but not for tox
